### PR TITLE
Add log rotation functionality

### DIFF
--- a/fshook.go
+++ b/fshook.go
@@ -2,17 +2,63 @@ package dugong
 
 import (
 	"fmt"
+	log "github.com/Sirupsen/logrus"
 	"os"
 	"sync/atomic"
-
-	log "github.com/Sirupsen/logrus"
+	"time"
 )
+
+// RotationScheduler determines when files should be rotated.
+type RotationScheduler interface {
+	// ShouldRotate returns true if the file should be rotated. The suffix to apply
+	// to the filename is returned as the 2nd arg.
+	ShouldRotate() (bool, string)
+}
+
+// DailyRotationSchedule rotates log files daily. Logs are only rotated
+// when midnight passes *whilst the process is running*. E.g: if you run
+// the process on Day 4 then stop it and start it on Day 7, no rotation will
+// occur when the process starts.
+type DailyRotationSchedule struct {
+	rotateAfter *time.Time
+}
+
+var currentTime = time.Now // exclusively for testing
+
+func dayOffset(t time.Time, offsetDays int) time.Time {
+	// GoDoc:
+	//   The month, day, hour, min, sec, and nsec values may be outside their
+	//   usual ranges and will be normalized during the conversion.
+	//   For example, October 32 converts to November 1.
+	return time.Date(
+		t.Year(), t.Month(), t.Day()+offsetDays, 0, 0, 0, 0, t.Location(),
+	)
+}
+
+func (rs *DailyRotationSchedule) ShouldRotate() (bool, string) {
+	now := currentTime()
+	if rs.rotateAfter == nil {
+		nextRotate := dayOffset(now, 1)
+		rs.rotateAfter = &nextRotate
+		return false, ""
+	}
+	if now.After(*rs.rotateAfter) {
+		// the suffix should be actually the date of the complete day being logged
+		actualDay := dayOffset(*rs.rotateAfter, -1)
+		suffix := "." + actualDay.Format("2006-01-02") // YYYY-MM-DD
+		nextRotate := dayOffset(now, 1)
+		rs.rotateAfter = &nextRotate
+		return true, suffix
+	}
+	return false, ""
+}
 
 // NewFSHook makes a logging hook that writes formatted
 // log entries to info, warn and error log files. Each log file
 // contains the messages with that severity or higher. If a formatter is
-// not specified, they will be logged using a JSON formatter.
-func NewFSHook(infoPath, warnPath, errorPath string, formatter log.Formatter) log.Hook {
+// not specified, they will be logged using a JSON formatter. If a
+// RotationScheduler is set, the files will be cycled according to its rules.
+func NewFSHook(infoPath, warnPath, errorPath string, formatter log.Formatter, rotSched RotationScheduler) log.Hook {
 	if formatter == nil {
 		formatter = &log.JSONFormatter{}
 	}
@@ -22,6 +68,7 @@ func NewFSHook(infoPath, warnPath, errorPath string, formatter log.Formatter) lo
 		warnPath:  warnPath,
 		errorPath: errorPath,
 		formatter: formatter,
+		scheduler: rotSched,
 	}
 
 	go func() {
@@ -43,6 +90,7 @@ type fsHook struct {
 	warnPath  string
 	errorPath string
 	formatter log.Formatter
+	scheduler RotationScheduler
 }
 
 func (hook *fsHook) Fire(entry *log.Entry) error {
@@ -55,6 +103,14 @@ func (hook *fsHook) writeEntry(entry *log.Entry) error {
 	msg, err := hook.formatter.Format(entry)
 	if err != nil {
 		return nil
+	}
+
+	if hook.scheduler != nil {
+		if should, suffix := hook.scheduler.ShouldRotate(); should {
+			if err := hook.rotate(suffix); err != nil {
+				return err
+			}
+		}
 	}
 
 	if entry.Level <= log.ErrorLevel {
@@ -86,6 +142,23 @@ func (hook *fsHook) Levels() []log.Level {
 		log.WarnLevel,
 		log.InfoLevel,
 	}
+}
+
+// rotate all the log files to the given suffix.
+// If error path is "err.log" and suffix is "1" then move
+// the contents to "err.log1".
+// This requires no locking as the goroutine calling this is the same
+// one which does the logging. Since we don't hold open a handle to the
+// file when writing, a simple Rename is all that is required.
+func (hook *fsHook) rotate(suffix string) error {
+	for _, fpath := range []string{hook.errorPath, hook.warnPath, hook.infoPath} {
+		if err := os.Rename(fpath, fpath+suffix); err != nil {
+			// e.g. because there were no errors in error.log for this day
+			fmt.Fprintf(os.Stderr, "Error rotating file %s: %v\n", fpath, err)
+		}
+
+	}
+	return nil
 }
 
 func logToFile(path string, msg []byte) error {

--- a/fshook_test.go
+++ b/fshook_test.go
@@ -3,6 +3,7 @@ package dugong
 import (
 	"bufio"
 	"encoding/json"
+	log "github.com/Sirupsen/logrus"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -10,8 +11,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-
-	log "github.com/Sirupsen/logrus"
+	"time"
 )
 
 const (
@@ -163,6 +163,108 @@ func TestFSHookConcurrent(t *testing.T) {
 	}
 }
 
+func TestDailySchedule(t *testing.T) {
+	loc, err := time.LoadLocation("UTC")
+	if err != nil {
+		t.Fatalf("Failed to load location UTC: %s", err)
+	}
+
+	logger, hook, wait, teardown := setupLogHook(t)
+	defer teardown()
+	hook.scheduler = &DailyRotationSchedule{}
+
+	// Time ticks from 23:50 to 00:10 in 1 minute increments. Log each tick as 'counter'.
+	minutesGoneBy := 0
+	currentTime = func() time.Time {
+		minutesGoneBy += 1
+		return time.Date(2016, 10, 26, 23, 50+minutesGoneBy, 00, 0, loc)
+	}
+	for i := 0; i < 20; i++ {
+		t := time.Date(2016, 10, 26, 23, 50+i, 00, 0, loc)
+		logger.WithField("counter", i).Info("BASE " + t.Format(time.ANSIC))
+	}
+
+	wait()
+
+	// info.log.2016-10-26 should have 0 -> 9
+	checkFileHasSequentialCounts(t, hook.infoPath+".2016-10-26", 0, 9)
+
+	// info.log should have 10 -> 19 inclusive
+	checkFileHasSequentialCounts(t, hook.infoPath, 10, 19)
+}
+
+func TestDailyScheduleMultipleRotations(t *testing.T) {
+	loc, err := time.LoadLocation("UTC")
+	if err != nil {
+		t.Fatalf("Failed to load location UTC: %s", err)
+	}
+
+	logger, hook, wait, teardown := setupLogHook(t)
+	defer teardown()
+	hook.scheduler = &DailyRotationSchedule{}
+
+	// Time ticks every 12 hours from 13:37 -> 01:37 -> 13:37 -> ...
+	hoursGoneBy := 0
+	currentTime = func() time.Time {
+		hoursGoneBy += 12
+		// Start from 10/29 01:37
+		return time.Date(2016, 10, 28, 13+hoursGoneBy, 37, 00, 0, loc)
+	}
+	// log 2 lines per file, to 4 files (so 8 log lines)
+	for i := 0; i < 8; i++ {
+		ts := time.Date(2016, 10, 28, 13+((i+1)*12), 37, 00, 0, loc)
+		logger.WithField("counter", i).Infof("The time is now %s", ts)
+	}
+
+	wait()
+
+	// info.log.2016-10-29 should have 0-1
+	checkFileHasSequentialCounts(t, hook.infoPath+".2016-10-29", 0, 1)
+
+	// info.log.2016-10-30 should have 2-3
+	checkFileHasSequentialCounts(t, hook.infoPath+".2016-10-30", 2, 3)
+
+	// info.log.2016-10-31 should have 4-5
+	checkFileHasSequentialCounts(t, hook.infoPath+".2016-10-31", 4, 5)
+
+	// info.log should have 6-7 (current day is 11/01)
+	checkFileHasSequentialCounts(t, hook.infoPath, 6, 7)
+}
+
+// checkFileHasSequentialCounts based on a JSON "counter" key being a monotonically
+// incrementing integer. from and to are both inclusive.
+func checkFileHasSequentialCounts(t *testing.T, filepath string, from, to int) {
+	t.Logf("checkFileHasSequentialCounts(%s,%d,%d)", filepath, from, to)
+
+	file, err := os.Open(filepath)
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+		return
+	}
+
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	count := from
+	for scanner.Scan() {
+		data := make(map[string]interface{})
+		if err := json.Unmarshal([]byte(scanner.Text()), &data); err != nil {
+			t.Fatalf("%s : Failed to parse JSON: %v", file.Name(), err)
+		}
+		dataCounter := int(data["counter"].(float64))
+		t.Logf("%s want %d got %d", file.Name(), count, dataCounter)
+		if count != dataCounter {
+			t.Fatalf("%s : Counter: want %d got %d", file.Name(), count, dataCounter)
+		}
+
+		count++
+	}
+	count-- // never hit the next value
+
+	if count != to {
+		t.Fatalf("%s EOF: Want count %d got %d", file.Name(), to, count)
+	}
+}
+
 func setupLogHook(t *testing.T) (logger *log.Logger, hook *fsHook, wait func(), teardown func()) {
 	dir, err := ioutil.TempDir("", "TestFSHook")
 	if err != nil {
@@ -173,7 +275,7 @@ func setupLogHook(t *testing.T) (logger *log.Logger, hook *fsHook, wait func(), 
 	warnPath := filepath.Join(dir, "warn.log")
 	errorPath := filepath.Join(dir, "error.log")
 
-	hook = NewFSHook(infoPath, warnPath, errorPath, nil).(*fsHook)
+	hook = NewFSHook(infoPath, warnPath, errorPath, nil, nil).(*fsHook)
 
 	logger = log.New()
 	logger.Hooks.Add(hook)


### PR DESCRIPTION
Implement the one we actually care about: `DailyRotationSchedule`. Add tests
to assert that logs are actually being rotated and named correctly.

There are 2 known edge cases:
- Logs only rotate when midnight passes _whilst the process is running_. So if
  you had some logs, killed the process on Day 3, then turned it back on Day 7,
  the logs would NOT rotate on startup. We would need to store some external
  state somewhere if we wanted to do that.
- Logs only rotate _when something is logged_. So if you had lots of logging
  on Day 4, then nothing until Day 7, the logs would not rotate until Day 7.
