### PR TITLE
Fix logrus import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Logging utilities for [logrus](https://github.com/Sirupsen/logrus).
 
 To develop on this library, you need logrus on your GOPATH:
 
-  ``go get github.com/Sirupsen/logrus``
-  
+  ``go get github.com/sirupsen/logrus``
+
 You can then run its tests by running
 
   ``go test``

--- a/fshook.go
+++ b/fshook.go
@@ -3,7 +3,7 @@ package dugong
 import (
 	"compress/gzip"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"io"
 	"os"
 	"path/filepath"

--- a/fshook_test.go
+++ b/fshook_test.go
@@ -3,7 +3,7 @@ package dugong
 import (
 	"bufio"
 	"encoding/json"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
Fix the import path for logrus as the "s" from "sirupsen" isn't capitalised. Doesn't impact the import but using the wrong case and with third-party packages importing it with the right case will make the project impossible to build, causing errors like this one:

```
"github.com/Sirupsen/logrus".Hook does not implement "github.com/sirupsen/logrus".Hook (wrong type for Fire method)
    have Fire(*"github.com/Sirupsen/logrus".Entry) error
    want Fire(*"github.com/sirupsen/logrus".Entry) error
```