### PR TITLE
Put all logs in a single file

### DIFF
--- a/fshook.go
+++ b/fshook.go
@@ -3,12 +3,13 @@ package dugong
 import (
 	"compress/gzip"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"os"
 	"path/filepath"
 	"sync/atomic"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // RotationScheduler determines when files should be rotated.
@@ -41,6 +42,9 @@ func dayOffset(t time.Time, offsetDays int) time.Time {
 	)
 }
 
+// ShouldRotate compares the current time with the rotation schedule.
+// If the rotation should occur, returns (true, suffix) where suffix is the
+// suffix for the rotated file. Else, returns (false, "")
 func (rs *DailyRotationSchedule) ShouldRotate() (bool, string) {
 	now := currentTime()
 	if rs.rotateAfter == nil {
@@ -68,15 +72,13 @@ func (rs *DailyRotationSchedule) ShouldGZip() bool {
 // contains the messages with that severity or higher. If a formatter is
 // not specified, they will be logged using a JSON formatter. If a
 // RotationScheduler is set, the files will be cycled according to its rules.
-func NewFSHook(infoPath, warnPath, errorPath string, formatter log.Formatter, rotSched RotationScheduler) log.Hook {
+func NewFSHook(path string, formatter log.Formatter, rotSched RotationScheduler) log.Hook {
 	if formatter == nil {
 		formatter = &log.JSONFormatter{}
 	}
 	hook := &fsHook{
 		entries:   make(chan log.Entry, 1024),
-		infoPath:  infoPath,
-		warnPath:  warnPath,
-		errorPath: errorPath,
+		path:      path,
 		formatter: formatter,
 		scheduler: rotSched,
 	}
@@ -96,9 +98,7 @@ func NewFSHook(infoPath, warnPath, errorPath string, formatter log.Formatter, ro
 type fsHook struct {
 	entries   chan log.Entry
 	queueSize int32
-	infoPath  string
-	warnPath  string
-	errorPath string
+	path      string
 	formatter log.Formatter
 	scheduler RotationScheduler
 }
@@ -123,22 +123,8 @@ func (hook *fsHook) writeEntry(entry *log.Entry) error {
 		}
 	}
 
-	if entry.Level <= log.ErrorLevel {
-		if err := logToFile(hook.errorPath, msg); err != nil {
-			return err
-		}
-	}
-
-	if entry.Level <= log.WarnLevel {
-		if err := logToFile(hook.warnPath, msg); err != nil {
-			return err
-		}
-	}
-
-	if entry.Level <= log.InfoLevel {
-		if err := logToFile(hook.infoPath, msg); err != nil {
-			return err
-		}
+	if err := logToFile(hook.path, msg); err != nil {
+		return err
 	}
 
 	return nil
@@ -151,6 +137,7 @@ func (hook *fsHook) Levels() []log.Level {
 		log.ErrorLevel,
 		log.WarnLevel,
 		log.InfoLevel,
+		log.DebugLevel,
 	}
 }
 
@@ -161,17 +148,14 @@ func (hook *fsHook) Levels() []log.Level {
 // one which does the logging. Since we don't hold open a handle to the
 // file when writing, a simple Rename is all that is required.
 func (hook *fsHook) rotate(suffix string, gzip bool) error {
-	for _, fpath := range []string{hook.errorPath, hook.warnPath, hook.infoPath} {
-		logFilePath := fpath + suffix
-		if err := os.Rename(fpath, logFilePath); err != nil {
-			// e.g. because there were no errors in error.log for this day
-			fmt.Fprintf(os.Stderr, "Error rotating file %s: %v\n", fpath, err)
-			continue // don't try to gzip if we failed to rotate
-		}
-		if gzip {
-			if err := gzipFile(logFilePath); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to gzip file %s: %v\n", logFilePath, err)
-			}
+	logFilePath := hook.path + suffix
+	if err := os.Rename(hook.path, logFilePath); err != nil {
+		// e.g. because there were no errors in error.log for this day
+		fmt.Fprintf(os.Stderr, "Error rotating file %s: %v\n", hook.path, err)
+	} else if gzip {
+		// Don't try to gzip if we failed to rotate
+		if err := gzipFile(logFilePath); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to gzip file %s: %v\n", logFilePath, err)
 		}
 	}
 	return nil

--- a/fshook_test.go
+++ b/fshook_test.go
@@ -3,7 +3,6 @@ package dugong
 import (
 	"bufio"
 	"encoding/json"
-	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -12,6 +11,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -19,7 +20,7 @@ const (
 	fieldValue = "my_value"
 )
 
-func TestFSHookInfo(t *testing.T) {
+func TestFSHook(t *testing.T) {
 	logger, hook, wait, teardown := setupLogHook(t)
 	defer teardown()
 
@@ -27,32 +28,7 @@ func TestFSHookInfo(t *testing.T) {
 
 	wait()
 
-	checkLogFile(t, hook.infoPath, "info")
-}
-
-func TestFSHookWarn(t *testing.T) {
-	logger, hook, wait, teardown := setupLogHook(t)
-	defer teardown()
-
-	logger.WithField(fieldName, fieldValue).Warn("Warn message")
-
-	wait()
-
-	checkLogFile(t, hook.infoPath, "warning")
-	checkLogFile(t, hook.warnPath, "warning")
-}
-
-func TestFSHookError(t *testing.T) {
-	logger, hook, wait, teardown := setupLogHook(t)
-	defer teardown()
-
-	logger.WithField(fieldName, fieldValue).Error("Error message")
-
-	wait()
-
-	checkLogFile(t, hook.infoPath, "error")
-	checkLogFile(t, hook.warnPath, "error")
-	checkLogFile(t, hook.errorPath, "error")
+	checkLogFile(t, hook.path, "info")
 }
 
 func TestFsHookInterleaved(t *testing.T) {
@@ -67,7 +43,7 @@ func TestFsHookInterleaved(t *testing.T) {
 
 	wait()
 
-	file, err := os.Open(hook.infoPath)
+	file, err := os.Open(hook.path)
 	if err != nil {
 		t.Fatalf("Failed to open file: %v", err)
 	}
@@ -101,7 +77,7 @@ func TestFSHookMultiple(t *testing.T) {
 
 	wait()
 
-	file, err := os.Open(hook.infoPath)
+	file, err := os.Open(hook.path)
 	if err != nil {
 		t.Fatalf("Failed to open file: %v", err)
 	}
@@ -143,7 +119,7 @@ func TestFSHookConcurrent(t *testing.T) {
 	wg.Wait()
 	wait()
 
-	file, err := os.Open(hook.infoPath)
+	file, err := os.Open(hook.path)
 	if err != nil {
 		t.Fatalf("Failed to open file: %v", err)
 	}
@@ -176,7 +152,7 @@ func TestDailySchedule(t *testing.T) {
 	// Time ticks from 23:50 to 00:10 in 1 minute increments. Log each tick as 'counter'.
 	minutesGoneBy := 0
 	currentTime = func() time.Time {
-		minutesGoneBy += 1
+		minutesGoneBy++
 		return time.Date(2016, 10, 26, 23, 50+minutesGoneBy, 00, 0, loc)
 	}
 	for i := 0; i < 20; i++ {
@@ -186,11 +162,11 @@ func TestDailySchedule(t *testing.T) {
 
 	wait()
 
-	// info.log.2016-10-26 should have 0 -> 9
-	checkFileHasSequentialCounts(t, hook.infoPath+".2016-10-26", 0, 9)
+	// fshook.log.2016-10-26 should have 0 -> 9
+	checkFileHasSequentialCounts(t, hook.path+".2016-10-26", 0, 9)
 
-	// info.log should have 10 -> 19 inclusive
-	checkFileHasSequentialCounts(t, hook.infoPath, 10, 19)
+	// fshook.log should have 10 -> 19 inclusive
+	checkFileHasSequentialCounts(t, hook.path, 10, 19)
 }
 
 func TestDailyScheduleMultipleRotations(t *testing.T) {
@@ -210,7 +186,7 @@ func TestDailyScheduleMultipleRotations(t *testing.T) {
 		// Start from 10/29 01:37
 		return time.Date(2016, 10, 28, 13+hoursGoneBy, 37, 00, 0, loc)
 	}
-	// log 2 lines per file, to 4 files (so 8 log lines)
+	// log 8 lines
 	for i := 0; i < 8; i++ {
 		ts := time.Date(2016, 10, 28, 13+((i+1)*12), 37, 00, 0, loc)
 		logger.WithField("counter", i).Infof("The time is now %s", ts)
@@ -218,17 +194,17 @@ func TestDailyScheduleMultipleRotations(t *testing.T) {
 
 	wait()
 
-	// info.log.2016-10-29 should have 0-1
-	checkFileHasSequentialCounts(t, hook.infoPath+".2016-10-29", 0, 1)
+	// fshook.log.2016-10-29 should have 0-1
+	checkFileHasSequentialCounts(t, hook.path+".2016-10-29", 0, 1)
 
-	// info.log.2016-10-30 should have 2-3
-	checkFileHasSequentialCounts(t, hook.infoPath+".2016-10-30", 2, 3)
+	// fshook.log.2016-10-30 should have 2-3
+	checkFileHasSequentialCounts(t, hook.path+".2016-10-30", 2, 3)
 
-	// info.log.2016-10-31 should have 4-5
-	checkFileHasSequentialCounts(t, hook.infoPath+".2016-10-31", 4, 5)
+	// fshook.log.2016-10-31 should have 4-5
+	checkFileHasSequentialCounts(t, hook.path+".2016-10-31", 4, 5)
 
-	// info.log should have 6-7 (current day is 11/01)
-	checkFileHasSequentialCounts(t, hook.infoPath, 6, 7)
+	// fshook.log should have 6-7 (current day is 11/01)
+	checkFileHasSequentialCounts(t, hook.path, 6, 7)
 }
 
 // checkFileHasSequentialCounts based on a JSON "counter" key being a monotonically
@@ -271,11 +247,9 @@ func setupLogHook(t *testing.T) (logger *log.Logger, hook *fsHook, wait func(), 
 		t.Fatalf("Failed to make temporary directory: %v", err)
 	}
 
-	infoPath := filepath.Join(dir, "info.log")
-	warnPath := filepath.Join(dir, "warn.log")
-	errorPath := filepath.Join(dir, "error.log")
+	path := filepath.Join(dir, "fshook.log")
 
-	hook = NewFSHook(infoPath, warnPath, errorPath, nil, nil).(*fsHook)
+	hook = NewFSHook(path, nil, nil).(*fsHook)
 
 	logger = log.New()
 	logger.Hooks.Add(hook)


### PR DESCRIPTION
No longer differentiates log files, put everything in a single one.
Matches the new behavior stated in issue [#346](https://github.com/matrix-org/dendrite/issues/346).
Needed for PR [#379](https://github.com/matrix-org/dendrite/pull/379)