### PR TITLE
Create log files with 0660 mode

### DIFF
--- a/fshook.go
+++ b/fshook.go
@@ -162,7 +162,7 @@ func (hook *fsHook) rotate(suffix string, gzip bool) error {
 }
 
 func logToFile(path string, msg []byte) error {
-	fd, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
+	fd, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0660)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Open up access to allow group access to the log files, without granting other.

This is needed as forcing to user-only prevents the use of log archival systems that gain their access via a group.