### PR TITLE
Return an fsHook object

### DIFF
--- a/fshook.go
+++ b/fshook.go
@@ -72,7 +72,7 @@ func (rs *DailyRotationSchedule) ShouldGZip() bool {
 // contains the messages with that severity or higher. If a formatter is
 // not specified, they will be logged using a JSON formatter. If a
 // RotationScheduler is set, the files will be cycled according to its rules.
-func NewFSHook(path string, formatter log.Formatter, rotSched RotationScheduler) log.Hook {
+func NewFSHook(path string, formatter log.Formatter, rotSched RotationScheduler) *fsHook {
 	if formatter == nil {
 		formatter = &log.JSONFormatter{}
 	}

--- a/fshook.go
+++ b/fshook.go
@@ -72,7 +72,7 @@ func (rs *DailyRotationSchedule) ShouldGZip() bool {
 // contains the messages with that severity or higher. If a formatter is
 // not specified, they will be logged using a JSON formatter. If a
 // RotationScheduler is set, the files will be cycled according to its rules.
-func NewFSHook(path string, formatter log.Formatter, rotSched RotationScheduler) *fsHook {
+func NewFSHook(path string, formatter log.Formatter, rotSched RotationScheduler, options ...func(*fsHook)) log.Hook {
 	if formatter == nil {
 		formatter = &log.JSONFormatter{}
 	}
@@ -82,6 +82,10 @@ func NewFSHook(path string, formatter log.Formatter, rotSched RotationScheduler)
 		formatter:   formatter,
 		scheduler:   rotSched,
 		logFilePerm: 0660,
+	}
+
+	for _, option := range options {
+		option(hook)
 	}
 
 	go func() {
@@ -94,6 +98,12 @@ func NewFSHook(path string, formatter log.Formatter, rotSched RotationScheduler)
 	}()
 
 	return hook
+}
+
+func WithFileMode(mode os.FileMode) func(*fsHook) {
+	return func(hook *fsHook) {
+		hook.SetFilePerm(mode)
+	}
 }
 
 type fsHook struct {


### PR DESCRIPTION
Otherwise we can't actually get to the SetFilePerm method because
obviously it's not in the logger interface and the fsHook interface
isn't exported so we can't cast to it.

This seems to be enough but is this the corect go-y way of doing
this? Should we be exporting the interface anyway?